### PR TITLE
Update build.xml

### DIFF
--- a/ReactEmailDialogPlugin/build.xml
+++ b/ReactEmailDialogPlugin/build.xml
@@ -42,7 +42,7 @@
 		  	<env key="PATH" value="${env.PATH}${shellSeparator}${npmPath}"/>
 		  </exec>
 	</target>
-	<target name="npmBuild">
+	<target name="npmBuild" depends="npmInstall,installIBMColors">
 		  <exec executable="${shellCmd}" searchpath="true" dir="./react">
 		  	<arg value="${shellParam}"/>
 		  	<arg value="npm run build"/>


### PR DESCRIPTION
npmBuild:
     [exec] > icn-react@0.1.0 build C:\Users\regidio\workspaceEDP\ibm-content-navigator-samples\ReactEmailDialogPlugin\react
     [exec] > npm-run-all build-js
     [exec] 'npm-run-all' is not recognized as an internal or external command,

This was happing in parallel, it should wait to finish the install until init the build script