### PR TITLE
114202 Show userMessage from EDS error response

### DIFF
--- a/sampleEDSService/src/UpdateObjectTypeServlet.java
+++ b/sampleEDSService/src/UpdateObjectTypeServlet.java
@@ -1,9 +1,23 @@
 /*
- * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2010, 2019
- * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+ * Licensed Materials - Property of IBM (c) Copyright IBM Corp. 2012, 2020  All Rights Reserved.
+ * 
+ * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with
+ * IBM Corp.
+ * 
+ * DISCLAIMER OF WARRANTIES :
+ * 
+ * Permission is granted to copy and modify this Sample code, and to distribute modified versions provided that both the
+ * copyright notice, and this permission notice and warranty disclaimer appear in all copies and modified versions.
+ * 
+ * THIS SAMPLE CODE IS LICENSED TO YOU AS-IS. IBM AND ITS SUPPLIERS AND LICENSORS DISCLAIM ALL WARRANTIES, EITHER
+ * EXPRESS OR IMPLIED, IN SUCH SAMPLE CODE, INCLUDING THE WARRANTY OF NON-INFRINGEMENT AND THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL IBM OR ITS LICENSORS OR SUPPLIERS BE LIABLE FOR
+ * ANY DAMAGES ARISING OUT OF THE USE OF OR INABILITY TO USE THE SAMPLE CODE, DISTRIBUTION OF THE SAMPLE CODE, OR
+ * COMBINATION OF THE SAMPLE CODE WITH ANY OTHER CODE. IN NO EVENT SHALL IBM OR ITS LICENSORS AND SUPPLIERS BE LIABLE
+ * FOR ANY LOST REVENUE, LOST PROFITS OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE
+ * DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, EVEN IF IBM OR ITS LICENSORS OR SUPPLIERS HAVE
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
  */
-
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,13 +109,14 @@ public class UpdateObjectTypeServlet extends HttpServlet {
 		System.out.println("sampleEDService.UpdateObjectTypeServlet: Cookie="+request.getHeader("Cookie"));
 		try {
 		
-			// This looks for the word "error" as the value of any field.  If it is found, a general error is raised.  See the catch clause
-			// near the end of this method which demonstrates how to return the error so it appears to the user.
+			// This looks for the word "error" as the value of any field. If it is found, an error message (i.e., "Example of an error from EDS.")
+			// is returned and displayed to the user.
 			for (int j = 0; j < requestProperties.size(); j++) {
 				JSONObject requestProperty = (JSONObject)requestProperties.get(j);
 				String  value = String.valueOf(requestProperty.get("value"));
 				if (value.equals("error")) {
-					throw new Exception("Example of an error from EDS.");
+					sendErrorResponse(response, "EDS error details for logging.", "Example of an error from EDS.");
+					return;
 				}
 			}
 	
@@ -126,7 +141,6 @@ public class UpdateObjectTypeServlet extends HttpServlet {
 			// For both initial and in-progress calls, process the property data to add in choice lists and modified metadata
 			for (int i = 0; i < propertyData.size(); i++) {
 				JSONObject overrideProperty = (JSONObject)propertyData.get(i);
-				String overridePropertyName = overrideProperty.get("symbolicName").toString();
 				if (requestMode.equals("initialNewObject") || requestMode.equals("initialExistingObject") || requestMode.equals("inProgressChanges")) { 
 					if (overrideProperty.containsKey("dependentOn")) {
 						// perform dependent overrides (such as dependent choice lists) for inProgressChanges calls only
@@ -278,16 +292,37 @@ public class UpdateObjectTypeServlet extends HttpServlet {
 			jsonResponse.serialize(writer);
 	
 		} catch (Exception e) {
-			
-			// Send an error response json
-			response.setStatus(500);
-			JSONObject jsonResponse = new JSONObject();
-			jsonResponse.put("userMessage", e.getMessage());
-			System.out.println("  "+jsonResponse.serialize());
-			PrintWriter writer = response.getWriter();
-			jsonResponse.serialize(writer);
-			
+			sendErrorResponse(response, e.getMessage());
 		}
+	}
+	
+	/**
+	 * Sends a JSON error response.
+	 * 
+	 * @param response HTTP servlet response
+	 * @param errorMessage error message to be logged by the EDS plug-in (not displayed to the user)
+	 * @param userMessage error message to be displayed to the user
+	 * @throws IOException if an error occurs
+	 */
+	private void sendErrorResponse(HttpServletResponse response, String errorMessage, String userMessage) throws IOException {
+		response.setStatus(500);
+		JSONObject jsonResponse = new JSONObject();
+		jsonResponse.put("errorMessage", errorMessage);
+		jsonResponse.put("userMessage", userMessage);
+		System.out.println("  " + jsonResponse.serialize());
+		PrintWriter writer = response.getWriter();
+		jsonResponse.serialize(writer);
+	}
+	
+	/**
+	 * Sends a JSON error response.
+	 * 
+	 * @param response HTTP servlet response
+	 * @param errorMessage error message to be logged by the EDS plug-in (not displayed to the user)
+	 * @throws IOException if an error occurs
+	 */
+	private void sendErrorResponse(HttpServletResponse response, String errorMessage) throws IOException {
+		sendErrorResponse(response, errorMessage, null);
 	}
 	
 	private JSONArray  getPropertyData(String objectType, Locale locale) throws IOException {


### PR DESCRIPTION
- If a JSON error response includes the userMessage attribute, the associated message is displayed to the user
- New errorMessage attribute that if included in a JSON error response, it is logged by the EDS plug-in but not displayed to the user
- Requires IBM Content Navigator 3.0.9 or above, and the included EDS plug-in