### PR TITLE
Defect 114433 - fixed exception when the configStr is an empty string.

### DIFF
--- a/DocumentUploadFilterPlugin/src/com/ibm/ecm/extension/documentUploadFilter/DocumentUploadFilterPluginRequestFilter.java
+++ b/DocumentUploadFilterPlugin/src/com/ibm/ecm/extension/documentUploadFilter/DocumentUploadFilterPluginRequestFilter.java
@@ -53,13 +53,21 @@ public class DocumentUploadFilterPluginRequestFilter extends PluginRequestFilter
 		PluginLogger logger = callbacks.getLogger();
 		String repositoryId = request.getParameter("repositoryId");
 		String configStr = callbacks.loadConfiguration(); //contains allowed MIME types as an object {allowedTypes:[values]}
-		JSONObject configObj = JSONObject.parse(configStr);
-		JSONArray allowedTypes = (JSONArray)configObj.get("allowedTypes");
+		if (configStr == null || configStr.isEmpty()) {
+			return null;
+		}
+		
 		boolean validationErrors = true;
 
 		try {
+			JSONObject configObj = JSONObject.parse(configStr);
+			JSONArray allowedTypes = (JSONArray)configObj.get("allowedTypes");
 			String mimeType = request.getParameter("mimetype");
 
+			if (allowedTypes == null || allowedTypes.isEmpty()) {
+				return null;
+			}
+			
 			for (int i = 0; i < allowedTypes.size(); i++) {
 				String s = (String)allowedTypes.get(i);
 				if (s.equals(mimeType)) {


### PR DESCRIPTION
The exception occurs when the user registers the DocumentUploadFilterPlugin in Administration, but did not specify any mime type to include.
It should be working such that when there is nothing in the list, the gate should be opened to allow all mime type documents to be added.