### PR TITLE
Add additional language resource bundles to ICN

### DIFF
--- a/icn-dojo-nls/build.gradle
+++ b/icn-dojo-nls/build.gradle
@@ -96,22 +96,33 @@ def updateLocalesInGzip(sourcePath, sourceFile) {
 
 	// add extra locales
 	String[] locales = "$extraLocales".split(",")		
+	Boolean newStyle = true
 	file(origFilePath).withInputStream { stream ->
 		file(filePath).withWriter { writer ->
 			stream.eachLine { line ->
-				int index = line.indexOf(",\"ROOT")
-				if(index > 0) {
-					String newLine = line.substring(0, index) 
-					println "updateLocalesInGzip: original line\n" + line
-					locales.each { locale ->
-						newLine = newLine + ",\"" + locale + "\""
+				if (line.indexOf("i18n!*preload") > 0) {
+					int index = line.indexOf(",\"ROOT")
+					if(index == -1) {
+						index = line.indexOf(",\\\"ROOT")
+						newStyle = false
 					}
-					newLine = newLine + line.substring(index) 
-					println "updateLocalesInGzip: updated to\n" + newLine
-					writer.writeLine newLine
-				} else {
-					writer.writeLine line
+					if(index > 0) {
+						String newLine = line.substring(0, index) 
+						println "updateLocalesInGzip: original line\n" + line
+						locales.each { locale ->
+							if (newStyle) {
+								newLine = newLine + ",\"" + locale + "\""
+							} else {
+								newLine = newLine + ",\\\"" + locale + "\\\""
+							}
+						}
+						newLine = newLine + line.substring(index) 
+						println "updateLocalesInGzip: updated to\n" + newLine
+						writer.writeLine newLine
+						return
+					}
 				}
+				writer.writeLine line
 			}
 		}
 	}

--- a/icn-dojo-nls/build.gradle
+++ b/icn-dojo-nls/build.gradle
@@ -99,13 +99,15 @@ def updateLocalesInGzip(sourcePath, sourceFile) {
 	file(origFilePath).withInputStream { stream ->
 		file(filePath).withWriter { writer ->
 			stream.eachLine { line ->
-				int index = line.indexOf(",\\\"ROOT")
+				int index = line.indexOf(",\"ROOT")
 				if(index > 0) {
 					String newLine = line.substring(0, index) 
+					println "updateLocalesInGzip: original line\n" + line
 					locales.each { locale ->
-						newLine = newLine + ",\\\"" + locale + "\\\""
+						newLine = newLine + ",\"" + locale + "\""
 					}
 					newLine = newLine + line.substring(index) 
+					println "updateLocalesInGzip: updated to\n" + newLine
 					writer.writeLine newLine
 				} else {
 					writer.writeLine line


### PR DESCRIPTION
The gradle build script was last updated for ICN 309. The ecm.js of ICN 309 has locales line like 

(["dojo/i18n!\*preload\*ecm/nls/ecm\*[\\"ar\\",\\"cs\\",\\"ca\\",\\"da\\",\\"de\\",\\"el\\",\\"en\\",\\"en-ca\\",\\"en-gb\\",\\"es\\",\\"fi\\",\\"fr\\",\\"fr-ca\\",\\"he\\",\\"hr\\",\\"hu\\",\\"it\\",\\"ja\\",\\"kk\\",\\"ko\\",\\"nb-no\\",\\"nl\\",\\"no\\",\\"pl\\",\\"pt\\",\\"pt-br\\",\\"ru\\",\\"ro\\",\\"sk\\",\\"sl\\",\\"sv\\",\\"th\\",\\"tr\\",\\"vi\\",\\"zh\\",\\"zh-cn\\",\\"zh-tw\\",\\"ROOT\\"]"]);

yet ICN 3012 has locales like 

(['dojo/i18n!\*preload\*ecm/nls/ecm\*["ar","cs","ca","da","de","el","en","en-ca","en-gb","es","fi","fr","fr-ca","he","hr","hu","it","ja","kk","ko","nb-no","nl","no","pl","pt","pt-br","ru","ro","sk","sl","sv","th","tr","vi","zh","zh-cn","zh-tw","ROOT"]'])}}});

Revised the script that adds additional languages to make it work for ICN 3012.