### PR TITLE
DBACLD-97127 DocuSign: Lock icon is not shown for checkout items if sync

### DIFF
--- a/DocuSignSamplePlugin/DocuSignPlugin/src/main/java/com/ibm/icn/extension/docusign/WebContent/docuSign/util/DetailsViewDecorator.js
+++ b/DocuSignSamplePlugin/DocuSignPlugin/src/main/java/com/ibm/icn/extension/docusign/WebContent/docuSign/util/DetailsViewDecorator.js
@@ -42,6 +42,7 @@ define([
 			
 			return returnTag;
 		}
+		return returnTag;
 		
 	});
 


### PR DESCRIPTION
is not enabled