### PR TITLE
Update to IBM Content Navigator 3.0.15 iFix for CMOD & CM8

### DIFF
--- a/Containers/3.0.15/cluster_role.yaml
+++ b/Containers/3.0.15/cluster_role.yaml
@@ -18,18 +18,15 @@ metadata:
     app.kubernetes.io/name: ibm-icn
     release: 3.0.15
 rules:
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - list
+# Allow the operator to obtain the cluster's ingress domain for route creation
 - apiGroups:
   - operator.openshift.io
   resources:
   - ingresscontrollers
   verbs:
     - get
+
+# Allow the operator to determine the version of the installed operator, supporting all-namespace deployment
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -37,6 +34,8 @@ rules:
   verbs:
   - get
   - list
+
+# Allow the operator to check where the operator is running, supporting all-namespace deployment
 - apiGroups:
   - ""
   resources:
@@ -45,6 +44,8 @@ rules:
   - list
   - get
   - delete
+
+# Allow the operator to obtain the network type of the cluster to create egress policy CIDR ranges
 - apiGroups:
   - config.openshift.io
   resources:

--- a/Containers/3.0.15/ibm_icn_cr_production_FC_navigator.yaml
+++ b/Containers/3.0.15/ibm_icn_cr_production_FC_navigator.yaml
@@ -133,9 +133,9 @@ spec:
 
     ## This is the image repository and tag that correspond to shared images for all FNCM components.
     images:
-      keytool_job_container:
+      keytool_init_container:
         repository: icr.io/cpopen/icn/dba-keytool-initcontainer
-        tag: "23.0.2"
+        tag: "23.0.2-IF003"
 
     ## This is necessary if you want to use your own JDBC drivers and/or need to provide ICCSAP drivers.  If you are providing multiple JDBC drivers and ICCSAP drivers, 
     ## all the files must be compressed in a single file.
@@ -331,7 +331,7 @@ spec:
     image:
       ## The default repository is the IBM Entitled Registry
       repository: icr.io/cpopen/icn/navigator
-      tag: ga-3015-icn
+      tag: ga-3015-icn-la101
 
       ## This will override the image pull policy in the shared_configuration.
       pull_policy: IfNotPresent

--- a/Containers/3.0.15/operator.yaml
+++ b/Containers/3.0.15/operator.yaml
@@ -66,7 +66,7 @@ spec:
                       - ppc64le
       initContainers:
         - name: folder-prepare-container
-          image: "icr.io/cpopen/icp4a-content-operator:23.0.2"
+          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF003"
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -101,7 +101,7 @@ spec:
       containers:
         - name: operator
           # Replace this with the built image name
-          image: "icr.io/cpopen/icp4a-content-operator:23.0.2"
+          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF003"
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/Containers/README.rst
+++ b/Containers/README.rst
@@ -4,7 +4,7 @@ IBM Content Navigator Container Deployment for CMOD & CM8
 Introduction
 ------------
 
-Welcome to the IBM Content Navigator Container Deployment for CMOD & CM8 readme! This readme provides instructions for preparation and deployment of IBM Content Navigator in a kubernettes environment.
+Welcome to the IBM Content Navigator Container Deployment for CMOD & CM8 readme! This readme provides instructions for preparation and deployment of IBM Content Navigator in a kubernetes environment.
 For more details on IBM Content Navigator, please refer to the provided `documentation <https://www.ibm.com/docs/en/content-navigator/3.0.15>`_.
 
 Currently supported version using the following instructions:
@@ -74,7 +74,7 @@ Complete the following tasks to prepare for your deployment:
                    * - Microsoft SQL Server
                      - 12.2.0
                    * - PostgreSQL
-                     - 42.6.0
+                     - 42.7.2
 
 
 #. Create the IBM Content Navigator namespace in your cluster.


### PR DESCRIPTION
Updated to the following: 

Operator updated 23.0.2IF3 
FullCR has been updated to 23.0.2IF3 images 
ClusterRole has been updated with reduced permissions 
