### PR TITLE
Update for IBM Content Navigator 3.0.15-IF003 GA

### DIFF
--- a/Containers/3.0.15/ibm_icn_cr_production_FC_navigator.yaml
+++ b/Containers/3.0.15/ibm_icn_cr_production_FC_navigator.yaml
@@ -137,7 +137,7 @@ spec:
     images:
       keytool_init_container:
         repository: icr.io/cpopen/icn/dba-keytool-initcontainer
-        tag: "23.0.2-IF004"
+        tag: "23.0.2-IF006"
 
     ## This is necessary if you want to use your own JDBC drivers and/or need to provide ICCSAP drivers.  If you are providing multiple JDBC drivers and ICCSAP drivers, 
     ## all the files must be compressed in a single file.
@@ -333,7 +333,7 @@ spec:
     image:
       ## The default repository is the IBM Entitled Registry
       repository: icr.io/cpopen/icn/navigator
-      tag: ga-3015-icn-if002
+      tag: ga-3015-icn-if003
 
       ## This will override the image pull policy in the shared_configuration.
       pull_policy: IfNotPresent
@@ -352,7 +352,7 @@ spec:
       limits:
         cpu: "1"
         memory: "3072Mi"
-        ephemeral_storage: "2.5Gi"
+        ephemeral_storage: "3Gi"
 
       ## By default "Autoscaling" is disabled (i.e., enabled: false).  If you enable auto_scaling (i.e., enabled: true), be sure to 
       ## provide values for max_replicas, min_replicas, and target_cpu_utilization_percentage.

--- a/Containers/3.0.15/operator.yaml
+++ b/Containers/3.0.15/operator.yaml
@@ -66,7 +66,7 @@ spec:
                       - ppc64le
       initContainers:
         - name: folder-prepare-container
-          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF004"
+          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF006"
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -101,7 +101,7 @@ spec:
       containers:
         - name: operator
           # Replace this with the built image name
-          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF004"
+          image: "icr.io/cpopen/icp4a-content-operator:23.0.2-IF006"
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Updates to 3.0.15 release. 
Syned to CP4BA 23.0.2IF6 / FNCM 5.5.12IF2